### PR TITLE
Adds support for multiple URI from multiple TRE

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -1,6 +1,6 @@
 docker.enabled = true
 
 params {
-    sigfit_results_dir = "s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2/"
+    sigfit_results_dir = "s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2/,s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2_copy_3/"
     organ = "Breast"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ There are two primary input paramrters -
 
 | param | default | description | 
 |---|---|---|
-| sigfit_results_dir | null | The results output directory from [mutational-signature-nf] pipeline |
+| sigfit_results_dir | null | The results output directory from [mutational-signature-nf] pipeline, mutiple URI paths separated by coma |
 | organ | "Breast" | Which organ was used while running [mutational-signature-nf] pipeline |
 
 ## Output
@@ -23,9 +23,14 @@ Output generates a table (TSV file) and plot with combined results of all the sa
 
 ## Usage
 
+Collect mutiple TRE results s3 bucket as shown in the example bellow - 
+
+* TRE-1 results - `s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2/`
+* TRE-2 results - `s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2_copy_3/`
+
 ```bash
 nextflow run main.nf \
-    --sigfit_results_dir "s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out/" \
+    --sigfit_results_dir "s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2/,s3://lifebit-featured-datasets/pipelines/mutational-signature-nf/example-output/sigfit_results_out_v2_copy_3/" \
     --organ "Breast"
 ```
 


### PR DESCRIPTION
## Description 

As the connect platform will pass multiple S3 URI paths from multiple TREs, the aggregation pipeline needs to collect all the results in order to aggregate them, 

## Changes 

* Earlier, the param `sigfit_results_dir` used to accept only one S3 URI path, but now can take multiple paths by comma separated.

## Test 

```
nextflow run main.nf -profile test
```

<img width="970" alt="image" src="https://user-images.githubusercontent.com/23085664/175065718-65bf6195-51b8-4ae4-a31b-5853d9dc42e3.png">


Also `test.config` updated. So CI test should be covering it.